### PR TITLE
Bump up MAXAPI to 29, to support Android 10

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -12,7 +12,7 @@
 # Uncomment DYNLIB if you want libs installed to vendor for oreo+ and system for anything older
 # Uncomment DEBUG if you want full debug logs (saved to /sdcard)
 MINAPI=22
-MAXAPI=28
+MAXAPI=29
 #DYNLIB=true
 #DEBUG=true
 


### PR DESCRIPTION
For example, the Pixel Experience ROM has been updated to Android 10. Would be good to have this module working again.
I don't know if other changes would be required (i.e. updating the `module.prop` file...?)